### PR TITLE
Fix fmt str

### DIFF
--- a/eigerApp/src/eigerDetector.cpp
+++ b/eigerApp/src/eigerDetector.cpp
@@ -43,14 +43,14 @@
     driverName, functionName, msg)
 
 #define ERR_ARGS(fmt,...) asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, \
-    "%s::%s: "fmt"\n", driverName, functionName, __VA_ARGS__);
+    "%s::%s: " fmt "\n", driverName, functionName, __VA_ARGS__);
 
 // Flow message formatters
 #define FLOW(msg) asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s::%s: %s\n", \
     driverName, functionName, msg)
 
 #define FLOW_ARGS(fmt,...) asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, \
-    "%s::%s: "fmt"\n", driverName, functionName, __VA_ARGS__);
+    "%s::%s: " fmt "\n", driverName, functionName, __VA_ARGS__);
 
 using std::string;
 using std::vector;

--- a/eigerApp/src/eigerParam.cpp
+++ b/eigerApp/src/eigerParam.cpp
@@ -17,7 +17,7 @@
     mAsynName.c_str(), functionName, msg)
 
 #define ERR_ARGS(fmt,...) asynPrint(mSet->getUser(), ASYN_TRACE_ERROR, \
-    "Param[%s]::%s: "fmt"\n", mAsynName.c_str(), functionName, __VA_ARGS__);
+    "Param[%s]::%s: " fmt "\n", mAsynName.c_str(), functionName, __VA_ARGS__);
 
 // Flow message formatters
 #define FLOW(msg) asynPrint(mSet->getUser(), ASYN_TRACE_FLOW, \
@@ -25,7 +25,7 @@
     mAsynName.c_str(), functionName, msg)
 
 #define FLOW_ARGS(fmt,...) asynPrint(mSet->getUser(), ASYN_TRACE_FLOW, \
-    "Param[%s]::%s: "fmt"\n", mAsynName.c_str(), functionName, __VA_ARGS__);
+    "Param[%s]::%s: " fmt "\n", mAsynName.c_str(), functionName, __VA_ARGS__);
 
 
 #define MAX_BUFFER_SIZE 128

--- a/eigerApp/src/streamApi.cpp
+++ b/eigerApp/src/streamApi.cpp
@@ -16,7 +16,7 @@
 #define ERR_PREFIX  "StreamApi"
 #define ERR(msg) fprintf(stderr, ERR_PREFIX "::%s: %s\n", functionName, msg)
 
-#define ERR_ARGS(fmt,...) fprintf(stderr, ERR_PREFIX "::%s: "fmt"\n", \
+#define ERR_ARGS(fmt,...) fprintf(stderr, ERR_PREFIX "::%s: " fmt "\n", \
         functionName, __VA_ARGS__)
 
 using std::string;


### PR DESCRIPTION
This resolved number of ADEiger compile errors on Debian 9 related to C++11 string formating, as discussed in the epics-core. tech-talk.

https://epics.anl.gov/core-talk/2019/msg00506.php

../eigerDetector.cpp:46:18: error: unable to find string literal operator ‘operator""fmt’ with ‘const char [10]’, ‘long unsigned int’ arguments
     "%s::%s: "fmt"\n", driverName, functionName, __VA_ARGS__);

====
g++ --version  => g++ (Debian 6.3.0-18+deb9u1) 6.3.0 20170516
