### PR TITLE
Fix stream

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,14 @@ https://github.com/areaDetector/ADEiger/releases.
 
 Release Notes
 =============
+R3-1 (November XXX, 2021)
+----
+* Fixed a race condition with the Stream interface.
+  - The detector sends the first message over the ZMQ socket as soon as the "arm" command is sent when starting acquisition.
+  - However, the driver was not creating the ZMQ socket to receive those messages until after the "arm" command was sent.
+    This was a race condition.  It was failing on an Eiger2 at APS sector 34.
+  - This release creates the ZMQ socket before acquisition begins.
+
 R3-0 (June 25, 2021)
 ----
 * Added support for Eiger2 detectors.

--- a/eigerApp/src/eigerDetector.cpp
+++ b/eigerApp/src/eigerDetector.cpp
@@ -1278,11 +1278,11 @@ void eigerDetector::streamTask (void)
     lock();
     for(;;)
     {
+        StreamAPI api(mHostname);
+
         unlock();
         mStreamEvent.wait();
         lock();
-
-        StreamAPI api(mHostname);
 
         int err;
         stream_header_t header = {};

--- a/eigerApp/src/eigerDetector.cpp
+++ b/eigerApp/src/eigerDetector.cpp
@@ -59,7 +59,7 @@ using std::string;
 using std::vector;
 using std::map;
 
-static const string DRIVER_VERSION("3.0.0");
+static const string DRIVER_VERSION("3.1.0");
 
 enum data_source
 {


### PR DESCRIPTION
This fixes #47 .  

However, it changes the logic such that there is always an open zmq_socket, even when the stream interface is not being used, because the StreamAPI object is created before the streamEvent is received.

An alternative fix would be to move the "arm" command in controlTask to be sent *after" sending the streamEvent signal to wake up the streamTask.