### PR TITLE
Fix stream global header htype

### DIFF
--- a/eigerApp/src/streamApi.cpp
+++ b/eigerApp/src/streamApi.cpp
@@ -179,7 +179,7 @@ int StreamAPI::getHeader (stream_header_t *header, int timeout)
         if((err = readToken(tokens, "htype", htype)))
             goto exit;
 
-        string expectedHType("dheader");
+        string expectedHType("dheader-1.0");
         if(htype.compare(0, expectedHType.length(), expectedHType))
         {
             ERR_ARGS("wrong header type, htype=%s", htype.c_str());


### PR DESCRIPTION
The three Eiger (500K, 1M, 4M) immediately start with this change.
I have not seen the error about wrong header type after the change for stream module.

"StreamApi::getHeader: wrong header type, htype=dconfig-1.0"