### PR TITLE
Fix problem with stopping a series

### DIFF
--- a/eigerApp/src/eigerDetector.cpp
+++ b/eigerApp/src/eigerDetector.cpp
@@ -1323,7 +1323,6 @@ void eigerDetector::streamTask (void)
         {
             unlock();
             err = mStreamAPI->getHeader(&header, 1);
-            printf("getHeader returned %d\n", err);
             lock();
             if ( err == STREAM_SUCCESS) {
                 break;
@@ -1364,7 +1363,6 @@ void eigerDetector::streamTask (void)
             {
                 unlock();
                 err = mStreamAPI->getFrame(&frame, 1);
-                printf("getFrame returned %d\n", err);
                 lock();
                 if (err == STREAM_SUCCESS) {
                     break;
@@ -1378,7 +1376,6 @@ void eigerDetector::streamTask (void)
                     {
                         // This means acquisition was stopped during a series
                         // We need to either wait for all ZMQ data that is pending or close and re-open the socket.
-                        printf("Waiting for frame, acquiring() is false, restarting streamAP\n");
                         delete mStreamAPI;
                         mStreamAPI = new StreamAPI(mHostname);
                         goto end;

--- a/eigerApp/src/eigerDetector.cpp
+++ b/eigerApp/src/eigerDetector.cpp
@@ -1323,26 +1323,26 @@ void eigerDetector::streamTask (void)
         {
             unlock();
             err = mStreamAPI->getHeader(&header, 1);
+            printf("getHeader returned %d\n", err);
             lock();
-            switch (err)
-            {
-                case STREAM_SUCCESS:
-                    break;
-                case STREAM_WRONG_HTYPE:
-                    ERR("got stray packet, ignoring");
-                    continue;
-                case STREAM_ERROR:
-                    ERR("failed to get header packet");
-                    goto end;
-                case STREAM_TIMEOUT:
-                    FLOW("got stream timeout");
-                    continue;
-                default:
-                    ERR("unknown err from mStreamAPI->getHeader()");
-                    goto end;
+            if ( err == STREAM_SUCCESS) {
+                break;
+            } else if (err == STREAM_WRONG_HTYPE) {
+                ERR("got stray packet, ignoring");
+                continue;
+            } else if (err == STREAM_ERROR) {
+                ERR("failed to get header packet");
+                goto end;
+            } else if (err == STREAM_TIMEOUT) {
+                FLOW("got stream timeout");
+                continue;
+            } else {
+                ERR("unknown err from mStreamAPI->getHeader()");
+                goto end;
             }
             if(!acquiring())
             {
+                printf("Waiting for frame, acquiring() is false, restarting streamAP\n");
                 // This means acquisition was stopped during a series
                 // We need to either wait for all ZMQ data that is pending or close and re-open the socket.
                 delete mStreamAPI;
@@ -1358,25 +1358,25 @@ void eigerDetector::streamTask (void)
             {
                 unlock();
                 err = mStreamAPI->getFrame(&frame, 1);
+                printf("getFrame returned %d\n", err);
                 lock();
-                switch (err)
-                {
-                    case STREAM_SUCCESS:
-                        break;
-                    case STREAM_ERROR:
-                        ERR("failed to get frame packet");
-                        goto end;
-                    case STREAM_TIMEOUT:
-                        FLOW("got stream timeout");
-                        continue;
-                    default:
-                        ERR("unknown err from mStreamAPI->getFrame()");
-                        goto end;
+                if (err == STREAM_SUCCESS) {
+                    break;
+                } else if (err == STREAM_ERROR) {
+                    ERR("failed to get frame packet");
+                    goto end;
+                } else if (err == STREAM_TIMEOUT) {
+                    FLOW("got stream timeout");
+                    continue;
+                } else {
+                    ERR("unknown err from mStreamAPI->getFrame()");
+                    goto end;
                 }
                 if(!acquiring())
                 {
                     // This means acquisition was stopped during a series
                     // We need to either wait for all ZMQ data that is pending or close and re-open the socket.
+                    printf("Waiting for frame, acquiring() is false, restarting streamAP\n");
                     delete mStreamAPI;
                     mStreamAPI = new StreamAPI(mHostname);
                     goto end;

--- a/eigerApp/src/eigerDetector.cpp
+++ b/eigerApp/src/eigerDetector.cpp
@@ -995,7 +995,7 @@ void eigerDetector::controlTask (void)
             mNumImages->put(numImages);
 
         getIntegerParam(ADStatus, &adStatus);
-        if(adStatus == ADStatusAcquire || (adStatus == ADStatusAborted && success))
+        if(adStatus == ADStatusAcquire)
             setIntegerParam(ADStatus, ADStatusIdle);
         else if(adStatus == ADStatusAborted)
             setStringParam(ADStatusMessage, "Acquisition aborted");
@@ -1324,24 +1324,31 @@ void eigerDetector::streamTask (void)
             unlock();
             err = mStreamAPI->getHeader(&header, 1);
             lock();
-            if (err == 0)
+            switch (err)
             {
-                break;
+                case STREAM_SUCCESS:
+                    break;
+                case STREAM_WRONG_HTYPE:
+                    ERR("got stray packet, ignoring");
+                    continue;
+                case STREAM_ERROR:
+                    ERR("failed to get header packet");
+                    goto end;
+                case STREAM_TIMEOUT:
+                    FLOW("got stream timeout");
+                    continue;
+                default:
+                    ERR("unknown err from mStreamAPI->getHeader()");
+                    goto end;
             }
-            if(err == STREAM_WRONG_HTYPE)
-            {
-                ERR("got stray packet, ignoring");
-                continue;
-            }
-
-            if(err == STREAM_ERROR)
-            {
-                ERR("failed to get header packet");
-                goto end;
-            }
-
             if(!acquiring())
+            {
+                // This means acquisition was stopped during a series
+                // We need to either wait for all ZMQ data that is pending or close and re-open the socket.
+                delete mStreamAPI;
+                mStreamAPI = new StreamAPI(mHostname);
                 goto end;
+            }
         }
 
         for(;;)
@@ -1352,18 +1359,28 @@ void eigerDetector::streamTask (void)
                 unlock();
                 err = mStreamAPI->getFrame(&frame, 1);
                 lock();
-                if (err == 0)
+                switch (err)
                 {
-                    break;
+                    case STREAM_SUCCESS:
+                        break;
+                    case STREAM_ERROR:
+                        ERR("failed to get frame packet");
+                        goto end;
+                    case STREAM_TIMEOUT:
+                        FLOW("got stream timeout");
+                        continue;
+                    default:
+                        ERR("unknown err from mStreamAPI->getFrame()");
+                        goto end;
                 }
-                if(err == STREAM_ERROR)
-                {
-                    ERR("failed to get frame packet");
-                    goto end;
-                }
-
                 if(!acquiring())
+                {
+                    // This means acquisition was stopped during a series
+                    // We need to either wait for all ZMQ data that is pending or close and re-open the socket.
+                    delete mStreamAPI;
+                    mStreamAPI = new StreamAPI(mHostname);
                     goto end;
+                }
             }
 
             if(frame.end)


### PR DESCRIPTION
This is an attempt to fix #56 

It does the following:
- Improves the legbility of streamTask by using switch statements and explicitly handling all values of stream_err.
- If aquisition is stopped then streamTask deletes and recreates mStreamAPI.  This closes and reopens the ZMQ socket, which flushes any existing data from the aborted scan.
- If an acquisition is stopped then StatusMessage_RBV will always be set to "Acquisition aborted".  Previously it was only set to that value if the frame.end was not received.  That was confusing.

This PR has not been tested, so please do not merge it yet.  It can be used for testing at APS sectors 8, 12, and 13 for example.