### PR TITLE
base frame timestamps on epicsTS

### DIFF
--- a/eigerApp/src/eigerDetector.cpp
+++ b/eigerApp/src/eigerDetector.cpp
@@ -1458,10 +1458,8 @@ void eigerDetector::streamTask (void)
             // Put the frame number and timestamp into the buffer
             pArray->uniqueId = imageCounter;
 
-            epicsTimeStamp startTime;
-            epicsTimeGetCurrent(&startTime);
-            pArray->timeStamp = startTime.secPastEpoch + startTime.nsec / 1.e9;
             updateTimeStamp(&pArray->epicsTS);
+            pArray->timeStamp = pArray->epicsTS.secPastEpoch + pArray->epicsTS.nsec / 1.e9;
 
             // Update Omega angle for this frame
             ++mFrameNumber;
@@ -1586,8 +1584,6 @@ asynStatus eigerDetector::parseH5File (char *buf, size_t bufLen)
     size_t ndDims[2];
     NDDataType_t ndType;
 
-    epicsTimeStamp startTime;
-
     unsigned flags = H5LT_FILE_IMAGE_DONT_COPY | H5LT_FILE_IMAGE_DONT_RELEASE;
 
     // Open h5 file from memory
@@ -1702,9 +1698,8 @@ asynStatus eigerDetector::parseH5File (char *buf, size_t bufLen)
 
         // Put the frame number and time stamp into the buffer
         pImage->uniqueId = imageCounter;
-        epicsTimeGetCurrent(&startTime);
-        pImage->timeStamp = startTime.secPastEpoch + startTime.nsec / 1.e9;
         updateTimeStamp(&pImage->epicsTS);
+        pImage->timeStamp = pImage->epicsTS.secPastEpoch + pImage->epicsTS.nsec / 1.e9;
 
         // Update the omega angle for this frame
         ++mFrameNumber;
@@ -1811,10 +1806,8 @@ asynStatus eigerDetector::parseTiffFile (char *buf, size_t len)
 
     pImage->uniqueId = uniqueId++;
 
-    epicsTimeStamp ts;
-    epicsTimeGetCurrent(&ts);
-    pImage->timeStamp = ts.secPastEpoch + ts.nsec / 1.e9;
     updateTimeStamp(&pImage->epicsTS);
+    pImage->timeStamp = pImage->epicsTS.secPastEpoch + pImage->epicsTS.nsec / 1.e9;
 
     memcpy(pImage->pData, buf+8, dataLen);
     doCallbacksGenericPointer(pImage, NDArrayData, 1);

--- a/eigerApp/src/eigerDetector.cpp
+++ b/eigerApp/src/eigerDetector.cpp
@@ -1458,8 +1458,7 @@ void eigerDetector::streamTask (void)
             // Put the frame number and timestamp into the buffer
             pArray->uniqueId = imageCounter;
 
-            updateTimeStamp(&pArray->epicsTS);
-            pArray->timeStamp = pArray->epicsTS.secPastEpoch + pArray->epicsTS.nsec / 1.e9;
+            updateTimeStamps(pArray);
 
             // Update Omega angle for this frame
             ++mFrameNumber;
@@ -1698,8 +1697,7 @@ asynStatus eigerDetector::parseH5File (char *buf, size_t bufLen)
 
         // Put the frame number and time stamp into the buffer
         pImage->uniqueId = imageCounter;
-        updateTimeStamp(&pImage->epicsTS);
-        pImage->timeStamp = pImage->epicsTS.secPastEpoch + pImage->epicsTS.nsec / 1.e9;
+        updateTimeStamps(pImage);
 
         // Update the omega angle for this frame
         ++mFrameNumber;
@@ -1805,9 +1803,7 @@ asynStatus eigerDetector::parseTiffFile (char *buf, size_t len)
     }
 
     pImage->uniqueId = uniqueId++;
-
-    updateTimeStamp(&pImage->epicsTS);
-    pImage->timeStamp = pImage->epicsTS.secPastEpoch + pImage->epicsTS.nsec / 1.e9;
+    updateTimeStamps(pImage);
 
     memcpy(pImage->pData, buf+8, dataLen);
     doCallbacksGenericPointer(pImage, NDArrayData, 1);


### PR DESCRIPTION
Part of a series of PRs for AreaDetector repos that sets the outgoing frames' timeStamp member to be equal to the frame's epicsTS member, updated with updateTimeStamp, when not retreiving a timestamp from hardware.