### PR TITLE
Allow 8-bit bslz4 data without decompression from stream

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,6 +19,7 @@ R3-5 (July XXX, 2022)
 * Fix to only create and access High Voltage parameters on Eiger2.
   This fixes error messages when creating the detector object on Eiger detectors.
 * Allow 8-bit BSLZ4 data in Stream mode with Decompress=No (encoding "bs8-lz4<").
+* Correctly calculate size of BSLZ4 frames without their 12-byte header
 
 R3-4 (June 10, 2022)
 ----

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,7 @@ R3-5 (July XXX, 2022)
   This logic was accidentally removed when adding support for Continuous trigger mode.
 * Fix to only create and access High Voltage parameters on Eiger2.
   This fixes error messages when creating the detector object on Eiger detectors.
+* Allow 8-bit BSLZ4 data in Stream mode with Decompress=No (encoding "bs8-lz4<").
 
 R3-4 (June 10, 2022)
 ----

--- a/eigerApp/src/eigerDetector.cpp
+++ b/eigerApp/src/eigerDetector.cpp
@@ -1445,6 +1445,7 @@ void eigerDetector::streamTask (void)
                          (strcmp(frame.encoding, "bs8-lz4<") == 0)) {
                     pArray->codec.name = "bslz4";
                     pInput += 12;
+                    frame.compressedSize -= 12;
                 }
                 else {
                     ERR_ARGS("unknown encoding %s", frame.encoding);

--- a/eigerApp/src/eigerDetector.cpp
+++ b/eigerApp/src/eigerDetector.cpp
@@ -1441,7 +1441,8 @@ void eigerDetector::streamTask (void)
                     pArray->codec.name = "lz4";
                 }
                 else if ((strcmp(frame.encoding, "bs32-lz4<") == 0) ||
-                         (strcmp(frame.encoding, "bs16-lz4<") == 0)) {
+                         (strcmp(frame.encoding, "bs16-lz4<") == 0) ||
+                         (strcmp(frame.encoding, "bs8-lz4<") == 0)) {
                     pArray->codec.name = "bslz4";
                     pInput += 12;
                 }


### PR DESCRIPTION
In Stream mode with Decompress=false , 8bit BSLZ4 compressed data was not supported ("unsupported encoding" in console log). Tested with XPCS Eiger2 4M. With this change, we can acquire at 4500 Hz @ 8bit.