### PR TITLE
Increase Eiger2 minimum firmware to 2022.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Notes:
 ------
 
 * Depends on the Eiger1 having the firmware 1.6.4 or newer.
-* Depends on the Eiger2 having the firmware 2020.2 or newer.
+* Depends on the Eiger2 having the firmware 2022.1 or newer.
 * Depends on ADCore R3-5 and ADSupport R1-7 or newer.
 * This has only been tested on Linux 64-bit machines.
 

--- a/docs/ADEiger/eiger.rst
+++ b/docs/ADEiger/eiger.rst
@@ -21,7 +21,7 @@ Introduction
 
 This is an `EPICS`_ `areaDetector`_ driver for the Eiger and Eiger2 detectors
 from `Dectris`_. It has been tested on the Eiger 500K, 1M, 4M and 16M
-with the firmware version 1.6.4+, and Eiger2 with firmware 2020.2.
+with the firmware version 1.6.4+, and Eiger2 with firmware 2022.1.
 The driver communicates with the detector via its SIMPLON REST interface,
 so no library from Dectris is required. The images can pulled from the detector
 as HDF5 files, as a ZeroMQ stream or both.


### PR DESCRIPTION
ADEiger uses parameters `nexpi` and `extg_mode` for the Eiger2, which were added in firmware version 2022.1, so make that the minimum firmware for the Eiger2.