### PR TITLE
Change doc example trigger mode to External Series

### DIFF
--- a/documentation/eigerDoc.html
+++ b/documentation/eigerDoc.html
@@ -192,7 +192,7 @@
     of images of the acquisition and the FWNFilesPerImage PV.
   </p>
   <p>
-    For example, if TriggerMode is <b>External Enable</b>, NumImages is 60, NumTriggers
+    For example, if TriggerMode is <b>External Series</b>, NumImages is 60, NumTriggers
     is 2, FWNImagesPerFile is 100, Sequence ID for the acquisition is 1 and FWNamePattern
     is "series_$id", a total of three files will be generated:</p>
   <ul>


### PR DESCRIPTION
An example refers to an acquisition with TriggerMode set to "External Enable", but that mode only generates one image per trigger pulse, which does not make sense in the example.  Change the TriggerMode to "External Series", which generates N images per trigger pulse and is the intended TriggerMode for the example.